### PR TITLE
[HOTFIX] Stop PSM from loading high res images on page load

### DIFF
--- a/photoswipe-masonry.js
+++ b/photoswipe-masonry.js
@@ -38,7 +38,10 @@ var photoswipe_masonry = function($){
 
 		$.each(items, function(index, value) {
 			image[index]     = new Image();
-			image[index].src = value['src'];
+			/*
+			 * HOTFIX: Stop Photoswipe-Masonry from loading high res images on page load! Only thumbnails should be loaded!
+			 * image[index].src = value['src'];
+			 */
 		});
 
 		$pic.on('click', 'figure', function(event) {


### PR DESCRIPTION
Hot fixing a performance issue. Photoswipe-Masonry loads high res images on page load. Only thumbnails should be loaded on page load.
See [https://wordpress.org/support/topic/serious-performance-issue-3/](url)