### PR TITLE
Feature/add support for file gallery

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1,0 +1,47 @@
+/* PhotoSwipe Plugin - customize how your gallery looks here */
+/* TODO - good to expose it to plugin settings in future  */
+
+.psgal {
+    margin: auto;
+    padding-bottom: 40px;
+    -webkit-transition: all 0.4s ease;
+    -moz-transition: all 0.4s ease;
+    -o-transition: all 0.4s ease;
+    transition: all 0.4s ease;
+    opacity: 0.1;
+}
+
+.psgal.photoswipe_showme{
+    opacity: 1;
+}
+
+.psgal figure {
+    float: left;
+    text-align: center;
+    padding: 5px;
+    margin: 0px;
+    box-sizing: border-box;
+}
+
+.psgal a{
+    display:block;
+}
+
+.psgal img {
+    margin: auto;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    border: 0;
+}
+
+.psgal figure figcaption{
+    font-size: 13px;
+}
+
+.msnry {
+    margin: auto;
+}
+.pswp__caption__center{
+    text-align: center;
+}

--- a/file-gallery.php
+++ b/file-gallery.php
@@ -1,0 +1,106 @@
+<?php
+if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) {
+	die('Illegal Entry');
+}
+
+define('GALLERY_FOLDER', "fgallery");
+
+//============================== PhotoSwipe options ========================//
+class FileGallery {
+
+    public function get_images_from_folder($folderName, $thumbWidth) {
+        if (!function_exists('list_files')) { 
+            require_once ABSPATH . '/wp-admin/includes/file.php'; 
+        }
+        
+        $folderPath = 'wp-content/uploads/' . GALLERY_FOLDER . '/' . $folderName; 
+        $path = ABSPATH . $folderPath;
+        $files = list_files($path, 1);
+        $result = array();
+        if (is_null($files)) {
+            return $result; 
+        }
+
+        $jsonPath = $path . '/gallery.json';
+        $jsonText = file_get_contents($jsonPath);
+        if ($jsonText === false) {
+            $jsonText = '{';
+        }
+        $jsonData = json_decode($jsonText);
+
+        foreach ($files as $file) {
+            $fileInfo = pathinfo($file); 
+            $fileName = $fileInfo['basename'];
+            $fileExt = $fileInfo['extension'];
+            if ($fileName == 'thumbs' || $fileExt == 'json') {
+                continue;
+            }
+            $size = getimagesize($file);
+            $imageSrc = get_site_url(null, $folderPath . '/' .  $fileName); 
+            $imageThumbSrc = $this -> get_or_create_thumb($folderPath, $fileName, $thumbWidth);
+            $imageData = $this -> create_image_data($fileName, get_current_blog_id(), $jsonData, $size);
+
+            array_push($result, array (
+                'id' => $fileName,
+                'thumb' => $imageThumbSrc,
+                'full' => $imageSrc,
+                'data' => $imageData
+            ));
+        }
+
+        return $result;
+    }
+
+    function create_image_data($fileName, $siteId, $jsonData, $size) {
+        $imageData = array (
+            'x' => $size[0],
+            'y' => $size[1],
+            'title' => $fileName,
+            'alt' => $fileName,
+            'caption' => $fileName
+        );
+        if (is_null($jsonData)) {
+            return $imageData;
+        }
+        $data = $this -> read_json_entry($fileName, $jsonData, $siteId);
+        if (!is_null($data)) {
+            return $this -> assign_image_data($imageData, $data);
+        }
+        $data = $this -> read_json_entry('global', $jsonData, $siteId);
+        if (!is_null($data)) {
+            return $this -> assign_image_data($imageData, $data);
+        }
+        return $imageData;
+    }
+
+    function assign_image_data($imageData, $data) {
+        $imageData['caption'] = $data[0];
+        $imageData['alt'] = $data[1];
+        return $imageData;
+    }
+
+    function read_json_entry($entry, $jsonData, $siteId) {
+        $data = $jsonData->{$entry};
+        if (!is_null($data)) {
+            $data = $data->{strval($siteId)};
+        }
+        return $data;
+    }
+
+    function get_or_create_thumb($folderPath, $fileName, $thumbWidth) {
+        $thumbRelativePath = $folderPath . '/thumbs/thumbs_' . $fileName;
+        $thumbPath = ABSPATH . $thumbRelativePath; 
+        $imagePath = ABSPATH . '/' . $folderPath . '/' . $fileName; 
+        if (!file_exists($thumbPath)) {
+            $image = wp_get_image_editor($imagePath);
+            $size = $image->get_size();
+            $w = floatval($thumbWidth);
+            $ratio = floatval($size['height'])/$size['width']; 
+            $h = $w * $ratio;
+            $image->resize(round($w), round($h), false);
+            $image->save($thumbPath);
+        }
+        return get_site_url(null, $thumbRelativePath); 
+    }
+
+}

--- a/photoswipe-masonry.php
+++ b/photoswipe-masonry.php
@@ -322,7 +322,6 @@ add_action('wp_enqueue_scripts', 'photoswipe_scripts_method');
 
 add_shortcode( 'gallery', 'photoswipe_shortcode' );
 add_shortcode( 'photoswipe', 'photoswipe_shortcode' );
-add_shortcode( 'fgallery', 'photoswipe_folder_shortcode' );
 
 function photoswipe_shortcode( $attr ) {
 	global $post;


### PR DESCRIPTION
Also:
- Small DRY refactoring.
- Gallery CSS settings excluded from php to a separate file to be easier customized.

This implementation adds a folder argument to the [gallery] shortcode, that allows to read the files from a folder instead of attachments of the post.

### Why

This is very useful in scenario where I have many galleries in folders left from e.g. NextGen plugin, and now I want to easily adapt them to work with this plugin, without attaching all the existing files to posts manually. 

It also allows to manage the galleries separately from Wordpress database, and have a lot of control and automation over them. As all the information about captions is within folders in json files, the galleries will be easily movable to another websites or systems when needed. 

One more very useful feature, and why I needed this plugin first of all - is Multisite scenario. In multisite where I have several sites for different languages, I want only one gallery exist for all the sites, to not duplicate the galleries and their setup. This was not something existing plugins like NextGen gallery can solve. 

### Usage
e.g. [gallery folder="foo"] will read content from  
wp-content/uploads/fgallery/foo

The structure of the folder is simple 1-level collection of image files. The thumbnails are generated automatically on the first call of this folder gallery, but also can be placed manually for  custom thumbnails. The naming of thumbnails is matching NextGen gallery plugin. So if images are: foo/1.jpg, foo/2.jpg, then the thumb nails will be: foo/thumbs/thumbs_1.jpg, foo/thumbs/thumbs_2.jpg. This is generated automatically if doesn't exist.

The folder gallery also supports the gallery.json file, placed together with images. This file allows to define captions and alts for every image or globally for all the images in the given gallery for every site if multisite is used. 

If this file does not exist, the file name is taken by default as caption and alt. 

The gallery.json example:
```json
{
	"global": {
		"1": ["This will be the caption for all the pictures in this gallery on site 1", "Alt-all pictures"],
		"2": ["This will be the caption for all the pictures in this gallery on site 2", "Alt-all pictures"]
	},
	
	"foo.jpg": {
		"1": ["But this particular picture will have different caption in site 1", "alt"],
		"2": ["But this particular picture will have different caption in site 2", "alt"]
	}
}
```

Thus, if the particular picture record exists, it takes precedence, otherwise, the global information is used. 1 and 2 here are site ids.

### Tested

Tested locally in Wodpress 5.3.2 setup in Kubernetes cluster. Tested with multisite configuration, should just work good with single-site as well. 