### PR TITLE
Fix: Full resolution images download on page load

### DIFF
--- a/photoswipe-masonry.js
+++ b/photoswipe-masonry.js
@@ -36,10 +36,10 @@ var photoswipe_masonry = function($){
 
 		var items = getItems();
 
-		$.each(items, function(index, value) {
+		/*$.each(items, function(index, value) {
 			image[index]     = new Image();
 			image[index].src = value['src'];
-		});
+		});*/
 
 		$pic.on('click', 'figure', function(event) {
 
@@ -93,10 +93,10 @@ var photoswipe_masonry = function($){
 
 		var items = getItems();
 
-		$.each(items, function(index, value) {
+		/*$.each(items, function(index, value) {
 			image[index]     = new Image();
 			image[index].src = value['src'];
-		});
+		});*/
 
 		$pic.on('click', 'img', function(event) {
 


### PR DESCRIPTION
Photoswipe Masonry loads full resolution images on page load, but should be load only thumbnails.
Details here https://wordpress.org/support/topic/full-resolution-images-download-on-page-load/